### PR TITLE
Local database instead of Named Instance

### DIFF
--- a/Instructions/Labs/LAB_AK_10_Lab4_Ex2_Telemetry.md
+++ b/Instructions/Labs/LAB_AK_10_Lab4_Ex2_Telemetry.md
@@ -79,7 +79,7 @@ In this task, you will continue to be logged into LON-CL1 as Adam Hobbs, and you
 
 11. This initiates the **Office Telemetry Processor settings** wizard. The **Getting Started** window opens, but it may stay minimized on the taskbar. If so, select the icon to maximize the **Getting Started** window. On the **Getting Started** window, select **Next.**
 
-12. On the **Database Settings** page, select the **SQL Server** menu, select **(local)\TELEDASH** in the SQL Server menu, and then select **Connect**. 
+12. On the **Database Settings** page, select the **SQL Server** menu, select **(local)** in the SQL Server menu, and then select **Connect**. 
 
 13. In the **SQL database** box, type **Dashboard**, and then select **Create**. 
 


### PR DESCRIPTION
On the Database Settings page, select the SQL Server menu, select (local)\TELEDASH.
Should be: (local)
TELEDASH could be a named instance when you install SQL Express. Now SQL Server is installed on the Client so you can create a dashboard database direct on the local (i.e. LON-CL1) instance.

# Module: 10
## Lab/Demo: 02
### Exercise 2 Taks 2
Fixes # .
Telemetry dashboard can be created on the local database instance. Teledash doesn't exist.

Changes proposed in this pull request:

-
-
-