### PR TITLE
Scipt fails because of wrong capitalization in variable reference

### DIFF
--- a/Allfiles/ImportCsvToSharepointList.ps1
+++ b/Allfiles/ImportCsvToSharepointList.ps1
@@ -72,7 +72,7 @@ $ServiceRequestSystem
 
 foreach($Record in $ServiceRequestSystem){
 Add-PnPListItem -List "Service Desk Requests" -Values @{
-"issueTitle"= $Record.'IssueTitle';
+"IssueTitle"= $Record.'IssueTitle';
 "Date"= $Record.'Date';
 "Location"= $Record. 'Location';
 "Title"= $Record.'Issue Status';


### PR DESCRIPTION
During our training for MS-100 I found out that the script does not run through because the reference is wrong. Simple typo might also be good to test the "skills" in PowerShell of the trainees ;)

# Module: 4
## Lab/Demo: 3 Excercise 3

Step 25 ff

Changes proposed in this pull request:

- simple typo references wrong variable issueTitle instead of IssueTitle